### PR TITLE
Change to site.baseurl for dev site

### DIFF
--- a/pages/about/mission.md
+++ b/pages/about/mission.md
@@ -13,11 +13,11 @@ to target our activities and actions to serving these three aspects:
 
 
 
-## 1. Community 
+## 1. Community
 
   We seek to provide a coherent association of those who identify with
   the role (not necessarily title) of Research Software Engineer based
-  on our [inclusive definition]({{site.url}}/what-is-an-rse).  This
+  on our [inclusive definition]({{ site.baseurl }}/what-is-an-rse).  This
   group aims to provide the members of the community the ability to
   share knowledge, professional connections, and resources.
 
@@ -26,7 +26,7 @@ to target our activities and actions to serving these three aspects:
   We aim to promote RSEs' impact on research, highlighting the
   increasingly critical and valuable role RSEs serve.
 
-## 3. Resources 
+## 3. Resources
 
   We strive to provide useful resources to multiple demographics.
   For current and future RSEs we strive to provide technical and


### PR DESCRIPTION
I was poking around in mobile view and found this link didn't work on our dev site.  Changing {{ site.url }} to  {{ site.baseurl }}  did the trick since it's a project here.  I quick grep turned up a few more {{ site.url }}, which we could change too. But before I did, I wanted to check there weren't other implications. 