### PR TITLE
Working groups and navigation fixes

### DIFF
--- a/.github/workflows/clean-expired-jobs.yaml
+++ b/.github/workflows/clean-expired-jobs.yaml
@@ -30,7 +30,7 @@ jobs:
         print_all: false
         retry_count: 3
         timeout: 10
-        white_listed_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org
+        white_listed_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git
         white_listed_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/
 
     - name: Push Fixes

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -30,7 +30,7 @@ jobs:
         timeout: 10
 
         # White listed patterns (seem to have SSL issues but work in browser)
-        white_listed_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org
+        white_listed_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git
 
         # White list the following files
         white_listed_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/

--- a/_data/menus/about.yml
+++ b/_data/menus/about.yml
@@ -10,3 +10,6 @@
       link: /about/steering-committee/
     - name: Code of Conduct
       link: /about/code-of-conduct/
+    - name: Working Groups
+      link: /about/working-groups/
+

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,5 +1,5 @@
 - name: About
-  link: /#
+  link: about/
   dropdown:
     - name: About US-RSE
       link: about
@@ -13,8 +13,10 @@
       link: about/steering-committee/
     - name: Code of Conduct
       link: about/code-of-conduct/
+    - name: Working Groups
+      link: about/working-groups/
 - name: Events
-  link: /#
+  link: events/
   dropdown:
     - name: Events
       link: events
@@ -23,7 +25,7 @@
     - name: Archive
       link: events/archive/
 - name: Get Involved
-  link: /#
+  link: join/
   dropdown:
     - name: Join US-RSE
       link: join
@@ -34,12 +36,12 @@
     - name: Community Documents
       link: community-documents
 - name: Job Board
-  link: /#
+  link: jobs/
   dropdown:
     - name: Browse the board
       link: jobs
 - name: News
-  link: /#
+  link: news/
   dropdown:
     - name: Newsletters
       link: newsletters
@@ -49,17 +51,19 @@
       link: archive
 
 - name: Training
-  link: /#
+  link: links/
   dropdown:
     - name: Links
       link: links
 
 - name: External
-  link: /#
   dropdown:
     - name: RSE Map
       link: "https://usrse.github.io/usrse-map"
+      external: true
     - name: Community Blogs
       link: "https://usrse.github.io/blog"
+      external: true
     - name: Community Documents
       link: "https://github.com/USRSE/usrse.github.io/wiki"
+      external: true

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,7 +19,7 @@
                         <a href="{{ item.link | relative_url }}" class="navbar-link {% if item.link == page.url %}is-active{% endif %}">{{ item.name }}</a>
                         <div class="navbar-dropdown">
                             {% for subitem in item.dropdown %}
-                            <a href="{{ subitem.link | relative_url }}" class="navbar-item {% if subitem.link == page.url %}is-active{% endif %}">{{ subitem.name }}</a>
+                            <a {% if subitem.external %}target="_blank"{% endif %} href="{{ subitem.link | relative_url }}" class="navbar-item {% if subitem.link == page.url %}is-active{% endif %}">{{ subitem.name }}</a>
                             {% endfor %}
                         </div>
                     </div>

--- a/pages/about/working-groups.md
+++ b/pages/about/working-groups.md
@@ -18,4 +18,4 @@ The US-RSE Association is committed to providing an inclusive environment with e
 ### Website
 
 The US-RSE website working group assembled in late 2020/2021 to proactively work on the content and design of the US-RSE website.
-If you are interested in working on the site, or want to suggest features or a better design, you can join the `#website` channel on the US-RSE slack, or jump right in and start a discussion on <a href="https://github.com/usrse/usrse.github.io/issues">the GitHub issues board</a>.
+If you are interested in working on the site, or want to suggest features or a better design, you can join the `#website` channel on the US-RSE slack, or jump right in and start a discussion on the <a href="https://github.com/usrse/usrse.github.io/issues">GitHub issues board</a>.

--- a/pages/about/working-groups.md
+++ b/pages/about/working-groups.md
@@ -1,0 +1,22 @@
+---
+layout: page
+title: Working Groups
+permalink: /about/working-groups/
+subtitle: Focused groups to tackle community topics
+menubar: about
+menubar_toc: true
+---
+
+### Diversity, Equity, and Inclusion (DEI)
+
+The US-RSE Association is committed to providing an inclusive environment with equitable treatment for all and to promoting and encouraging diversity throughout the RSE community in the US. At US-RSE, integrating DEI practices into our education programs, governance structure, and culture is at the forefront of our mission to ensure a welcoming, nurturing, and robustly inclusive community. We believe that the amplification of diverse perspectives is essential for driving innovation, promoting creativity, and encouraging engagement for the success of RSEs. We welcome and respect individuals of any race, color, caste, economic status, gender expression, gender identity, sexual orientation, disabilityies, age, religion, national origin, and ethnicity. To get involved, visit the `#dei-discussion` channel on the US-RSE slack, or contact <a href="mailto:dei_wg@us-rse.org">The DEI working group list</a>.
+
+<i>A DEI working group page with more details is coming soon.</i>
+
+<hr>
+
+### Website
+
+The US-RSE website working group assembled in late 2020/2021 to proactively work on the content and design of the US-RSE website.
+If you are interested in working on the site, or want to suggest features or a better design, you can join the `#website` channel on the US-RSE slack, or jump right in and start a discussion on <a href="https://github.com/usrse/usrse.github.io/issues">the GitHub issues board</a>.
+

--- a/pages/about/working-groups.md
+++ b/pages/about/working-groups.md
@@ -9,7 +9,7 @@ menubar_toc: true
 
 ### Diversity, Equity, and Inclusion (DEI)
 
-The US-RSE Association is committed to providing an inclusive environment with equitable treatment for all and to promoting and encouraging diversity throughout the RSE community in the US. At US-RSE, integrating DEI practices into our education programs, governance structure, and culture is at the forefront of our mission to ensure a welcoming, nurturing, and robustly inclusive community. We believe that the amplification of diverse perspectives is essential for driving innovation, promoting creativity, and encouraging engagement for the success of RSEs. We welcome and respect individuals of any race, color, caste, economic status, gender expression, gender identity, sexual orientation, disabilityies, age, religion, national origin, and ethnicity. To get involved, visit the `#dei-discussion` channel on the US-RSE slack, or contact <a href="mailto:dei_wg@us-rse.org">The DEI working group list</a>.
+The US-RSE Association is committed to providing an inclusive environment with equitable treatment for all and to promoting and encouraging diversity throughout the RSE community in the US. At US-RSE, integrating DEI practices into our education programs, governance structure, and culture is at the forefront of our mission to ensure a welcoming, nurturing, and robustly inclusive community. We believe that the amplification of diverse perspectives is essential for driving innovation, promoting creativity, and encouraging engagement for the success of RSEs. We welcome and respect individuals of any race, color, caste, economic status, gender expression, gender identity, sexual orientation, disability, age, religion, national origin, and ethnicity. To get involved, visit the `#dei-discussion` channel on the US-RSE slack, or contact the <a href="mailto:dei_wg@us-rse.org">DEI working group list</a>.
 
 <i>A DEI working group page with more details is coming soon.</i>
 
@@ -19,4 +19,3 @@ The US-RSE Association is committed to providing an inclusive environment with e
 
 The US-RSE website working group assembled in late 2020/2021 to proactively work on the content and design of the US-RSE website.
 If you are interested in working on the site, or want to suggest features or a better design, you can join the `#website` channel on the US-RSE slack, or jump right in and start a discussion on <a href="https://github.com/usrse/usrse.github.io/issues">the GitHub issues board</a>.
-


### PR DESCRIPTION
This PR will do the following:

 - Add a basic working groups page under about to close #12 
 - Fixing links in main navigation so they link to their respective pages to close #27 
 - Ensure that external links actually open in a new tab (I don't think there is an associated issue but this was discussed a few meetings ago).

Signed-off-by: vsoch <vsoch@users.noreply.github.com>
