### PR TITLE
Use href attribute only with navigation bar items that are actually links.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,11 @@
                 {% for item in site.data.navigation %}
                     {% if item.dropdown %}
                     <div class="navbar-item has-dropdown is-hoverable {% if site.fixed_navbar == 'bottom' %} has-dropdown-up {% endif %}">
+                        {% if item.link %}
                         <a href="{{ item.link | relative_url }}" class="navbar-link {% if item.link == page.url %}is-active{% endif %}">{{ item.name }}</a>
+                        {% else %}
+                        <span class="navbar-link">{{ item.name }}</span>
+                        {% endif %}
                         <div class="navbar-dropdown">
                             {% for subitem in item.dropdown %}
                             <a {% if subitem.external %}target="_blank"{% endif %} href="{{ subitem.link | relative_url }}" class="navbar-item {% if subitem.link == page.url %}is-active{% endif %}">{{ subitem.name }}</a>


### PR DESCRIPTION
## Description
For navigation bar items in the header with no links, uses a `span` instead of an `a` in rendering.

## Motivation and Context
It's confusing to me to have my browser respond as if I'm hovering over a link only to find that clicking it takes me to exactly where I was before. If it's not really a link, best not to have the UI hint that it is.

## Checklist:
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers