### PR TITLE
Update/community docs

### DIFF
--- a/_data/menus/engage.yml
+++ b/_data/menus/engage.yml
@@ -6,6 +6,6 @@
       link: get-involved
     - name: Share
       link: share
-    - name: Community Documents
-      link: community-documents
+    - name: Community Whitepapers
+      link: community-whitepapers
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -33,8 +33,8 @@
       link: get-involved
     - name: Share
       link: share
-    - name: Community Documents
-      link: community-documents
+    - name: Community Whitepapers
+      link: community-whitepapers
 - name: Job Board
   link: jobs/
   dropdown:
@@ -63,7 +63,4 @@
       external: true
     - name: Community Blogs
       link: "https://usrse.github.io/blog"
-      external: true
-    - name: Community Documents
-      link: "https://github.com/USRSE/usrse.github.io/wiki"
       external: true

--- a/pages/engage/community-documents.md
+++ b/pages/engage/community-documents.md
@@ -1,14 +1,14 @@
 ---
 layout: page
-title: Community Documents
-description: Community Living Documents
-permalink: /community-documents/
+title: Community Whitepapers
+description: Collaborative community whitepapers
+permalink: /community-whitepapers/
 menubar: engage
 menubar_toc: true
 ---
 
 
-A community document is a living document that represents a community effort
+A community whitepaper is a living document that represents a community effort
 to discuss a question or idea. We call it "living" because we encourage community
 members to edit and contribute to the documents over time, and so there isn't
 a "publish" date associated with it. For this reason, we use [the wiki](https://github.com/USRSE/usrse.github.io/wiki) associated
@@ -16,36 +16,4 @@ with the repository here.
 
 ![{{ site.baseurl }}/assets/img/usrse-book-small.png]({{ site.baseurl }}/assets/img/usrse-book-small.png)
 
-If you ever need to clone this content, you can do:
-
-```bash
-$ git clone https://github.com/USRSE/usrse.github.io.wiki.git
-```
-
-NOTE: During the testing phase of the living documents, we currently plan for the wiki to only be editable by community (repository)
-members.
-
-## How do I edit an existing document?
-
-To edit a living document that already exists, you can browse the [wiki](https://github.com/USRSE/usrse.github.io/wiki) to find it and then update it. Generally, we are organizing topics as they are added, so if you want to add a new category or change the existing organization, please do so. 
-
-## How do I start a new document?
-
-If you want to add a new document, while you might add it directly to the wiki, it's recommended to get others
-involved first. You can ping others in the USRSE slack to contribute, and it's also recommended to start the document as a Google
-Document for easier commenting and editing, and then move to the wiki when it's in a final first draft state. 
-For all community documents, the following points apply:
-
-1. It's strongly suggested to first work on your document in Google Docs or similar, where you can bring in multiple community members to put together a first draft. Importantly, you should make sure that the content adheres to the US-RSE [Code of Conduct](https://us-rse.org/code-of-conduct/). It is suggested that you have discussion and work on the document with at least two other community members before submitting the document to the wiki. You should feel that it's in a solid "first draft state" before doing a submission.
-2. Make sure that you verify the following:
- - the content is of interest to the RSE community
- - the content does not violate the Code of Conduct. 
-  
-  _NOTE_: Any material added to the wiki that does not follow these rules is subject to removal. If you see content on the wiki that is not appropriate or otherwise breaks these rules, please open an issue on the repository immediately, or contact the steering committee.
-
-If you want to start a community document and would like some help or to talk with
-others, we encourage you to post on the US-RSE slack or write an issue here.
-
-
-
-
+You can read about how to clone and contribute to the documents [here](https://github.com/USRSE/usrse.github.io/wiki).

--- a/pages/engage/community-documents.md
+++ b/pages/engage/community-documents.md
@@ -16,4 +16,4 @@ with the repository here.
 
 ![{{ site.baseurl }}/assets/img/usrse-book-small.png]({{ site.baseurl }}/assets/img/usrse-book-small.png)
 
-You can read about how to clone and contribute to the documents [here](https://github.com/USRSE/usrse.github.io/wiki).
+You can read about how to clone and contribute to the documents <a href="https://github.com/USRSE/usrse.github.io/wiki" target="_blank">here</a>.

--- a/pages/engage/community-documents.md
+++ b/pages/engage/community-documents.md
@@ -10,7 +10,7 @@ menubar_toc: true
 
 A community whitepaper is a living document that represents a community effort
 to discuss a question or idea. We call it "living" because we encourage community
-members to edit and contribute to the documents over time, and so there isn't
+members to edit and contribute to the documents over time, so there isn't
 a "publish" date associated with it. For this reason, we use [the wiki](https://github.com/USRSE/usrse.github.io/wiki) associated
 with the repository here. 
 


### PR DESCRIPTION
As discussed in the call, this renames community documents to community white papers, and removes the extra external link. 