### PR TITLE
Update/job page

### DIFF
--- a/pages/opportunities/job-policy.md
+++ b/pages/opportunities/job-policy.md
@@ -4,8 +4,6 @@ title: US-RSE Job Posting Policy
 permalink: /job-policy/
 ---
 
-## Posting RSE-related Jobs on the US-RSE Job Board
-
 We happily post RSE and RSE-related job openings as a service to our community.
 There is currently no fee associated with posting to the [US-RSE job board]({{ site.baseurl }}/jobs/).
 We encourage RSE and RSE-related posts from all organization types (e.g. academic, industry, national labs, non-profits, etc.).

--- a/pages/opportunities/job-policy.md
+++ b/pages/opportunities/job-policy.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: US-RSE Job Posting Policy
+permalink: /job-policy/
+---
+
+## Posting RSE-related Jobs on the US-RSE Job Board
+
+We happily post RSE and RSE-related job openings as a service to our community.
+There is currently no fee associated with posting to the [US-RSE job board]({{ site.baseurl }}/jobs/).
+We encourage RSE and RSE-related posts from all organization types (e.g. academic, industry, national labs, non-profits, etc.).
+We expect any posted job to be open to individuals based in the United States.
+Non-US based postings will be considered, provided they are open to applicants from the United States.
+
+Each post will be reviewed for applicability to the US-RSE community.
+Jobs are considered applicable, regardless of title, if they contain a significant amount of Research Software Engineering as a core responsibility/requirement or are sufficiently adjacent to Research Software Engineering that some Research Software Engineers would be qualified and potentially interested.
+US-RSE organizers and maintainers reserve the right to not post a submitted job if it is deemed inappropriate or inapplicable.  
+
+Jobs can be submitted through the [US-RSE job submission google form](https://docs.google.com/forms/d/e/1FAIpQLSfYK64R1c0rj-ERldGLxuqedLIbsYPZXj9uBplDRYNmnND10Q/viewform?usp=sf_link).
+Once submitted, we will make every effort to review your submission quickly.
+If it is appropriate for our job board it should be posted within a few business days.  

--- a/pages/opportunities/job-policy.md
+++ b/pages/opportunities/job-policy.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: US-RSE Job Posting Policy
-permalink: /job-policy/
+permalink: /jobs/job-policy/
 ---
 
 We happily post RSE and RSE-related job openings as a service to our community.

--- a/pages/opportunities/job-policy.md
+++ b/pages/opportunities/job-policy.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: US-RSE Job Posting Policy
-permalink: /jobs/job-policy/
+permalink: /jobs/policy/
 ---
 
 We happily post RSE and RSE-related job openings as a service to our community.

--- a/pages/opportunities/jobs.md
+++ b/pages/opportunities/jobs.md
@@ -17,4 +17,4 @@ permalink: /jobs/
 <br>
 
 ### Have an RSE-related job posting?  
-Please read our [job posting policy]({{ site.baseurl }}/job-policy/) first, then fill out this [google form](https://docs.google.com/forms/d/e/1FAIpQLSfYK64R1c0rj-ERldGLxuqedLIbsYPZXj9uBplDRYNmnND10Q/viewform?usp=sf_link) to request additions to the job board.
+Please read our [job posting policy]({{ site.baseurl }}/jobs/policy/) first, then fill out this [google form](https://docs.google.com/forms/d/e/1FAIpQLSfYK64R1c0rj-ERldGLxuqedLIbsYPZXj9uBplDRYNmnND10Q/viewform?usp=sf_link) to request additions to the job board.

--- a/pages/opportunities/jobs.md
+++ b/pages/opportunities/jobs.md
@@ -17,4 +17,4 @@ permalink: /jobs/
 <br>
 
 ### Have an RSE-related job posting?  
-Fill out this [google form](https://docs.google.com/forms/d/e/1FAIpQLSfYK64R1c0rj-ERldGLxuqedLIbsYPZXj9uBplDRYNmnND10Q/viewform?usp=sf_link) to request additions to the list.
+Please read our [job posting policy]({{ site.baseurl }}/job-policy/) first, then fill out this [google form](https://docs.google.com/forms/d/e/1FAIpQLSfYK64R1c0rj-ERldGLxuqedLIbsYPZXj9uBplDRYNmnND10Q/viewform?usp=sf_link) to request additions to the job board.

--- a/pages/opportunities/jobs.md
+++ b/pages/opportunities/jobs.md
@@ -17,4 +17,4 @@ permalink: /jobs/
 <br>
 
 ### Have an RSE-related job posting?  
-Contact us via [slack](https://usrse.slack.com) or directly make a pull request in the website's [GitHub repository](https://github.com/USRSE/usrse.github.io).
+Fill out this [google form](https://docs.google.com/forms/d/e/1FAIpQLSfYK64R1c0rj-ERldGLxuqedLIbsYPZXj9uBplDRYNmnND10Q/viewform?usp=sf_link) to request additions to the list.


### PR DESCRIPTION
This PR addresses issues #28 and #29 via:

- A google form to take in the (as of now) required information to post a job to the board
- A policy page that spells out requirements/expectations for jobs posted to the job board

Both are linked from the jobs page.

As part of the review, if someone would give the google form a test run. I've set up email notification for each time the form is completed. 
