### PR TITLE
Add edu-training working group description

### DIFF
--- a/pages/about/working-groups.md
+++ b/pages/about/working-groups.md
@@ -19,3 +19,10 @@ The US-RSE Association is committed to providing an inclusive environment with e
 
 The US-RSE website working group assembled in late 2020/2021 to proactively work on the content and design of the US-RSE website.
 If you are interested in working on the site, or want to suggest features or a better design, you can join the `#website` channel on the US-RSE slack, or jump right in and start a discussion on the <a href="https://github.com/usrse/usrse.github.io/issues">GitHub issues board</a>.
+
+
+<hr>
+
+### Education & Training
+
+The Education & Training working group is for those that are interested in regular discussions about education and training for RSEs. The goal of the group is to develop resources and strategies that support RSE education and training and contribute to the establishment of a more formal career path for RSEs. Thus far, we have begun describing the types of people who work as RSEs and their training needs. We are also working on defining the list of skills often needed by RSEs. Furthermore, we’ve begun to assemble a list of resources for the US-RSE community, including a growing list of useful training links. The group currently meets monthly via Zoom and welcomes all newcomers. If you would like to join the conversation, please join the `#education-training` channel on the US-RSE Slack. 


### PR DESCRIPTION
This adds a single paragraph description of the Education and Training Working Group to the working groups description page. 


cc @usrse-maintainers
