### PR TITLE
Add Financial Pages

### DIFF
--- a/_data/menus/about.yml
+++ b/_data/menus/about.yml
@@ -10,6 +10,8 @@
       link: /about/what-is-an-rse/
     - name: Steering Committee
       link: /about/steering-committee/
+    - name: Finacial Status
+      link: /about/finances/
     - name: Code of Conduct
       link: /about/code-of-conduct/
     - name: Working Groups

--- a/_data/menus/get-involved.yml
+++ b/_data/menus/get-involved.yml
@@ -2,6 +2,8 @@
   items:
     - name: Join US-RSE
       link: join
+    - name: Support US-RSE
+      link: support
     - name: Get Involved
       link: get-involved
     - name: Share

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,6 +13,8 @@
       link: about/governance/
     - name: Steering Committee
       link: about/steering-committee/
+    - name: Finacial Status
+      link: /about/finances/
     - name: Code of Conduct
       link: about/code-of-conduct/
     - name: Working Groups
@@ -33,6 +35,8 @@
   dropdown:
     - name: Join US-RSE
       link: join
+    - name: Support US-RSE
+      link: support
     - name: Get Involved
       link: get-involved
     - name: Share

--- a/pages/about/finances.md
+++ b/pages/about/finances.md
@@ -1,0 +1,19 @@
+---
+layout: page
+title: US-RSE Financal Status
+permalink: about/finances/
+menubar: about
+---
+
+### Open Collective Foundation Member 
+
+The US Research Software Engineer Association is proud to be a member organization of the [Open Collective Foundation (OCF)](https://opencollective.com/foundation). 
+OCF is a 501(c)(3) fiscal host entity that provides US-RSE an open platform for transparently managing US-RSE long-term finances.
+The 501(c)(3) status and all of its benefits extend to all OCF member organizations including US-RSE. 
+OCF provides umbrella accounting, book-keeping and legal fiscal services for tax purposes to US-RSE. 
+
+The US-RSE home page under the OCF can be found here: [__https://opencollective.com/usrse__](https://opencollective.com/usrse).
+
+The page has a [__contribute__](https://opencollective.com/usrse#category-CONTRIBUTE) link which supports general donations to the US-RSE and a [__budget__]( https://opencollective.com/usrse#category-BUDGET)  link that provides a transparent picture of how US-RSE is using its funds. 
+
+For more information on current fundraising initiatives see the [support US-RSE page]({{ site.baseurl }}/get-involved/support/).

--- a/pages/get_involved/support.md
+++ b/pages/get_involved/support.md
@@ -1,0 +1,28 @@
+---
+layout: page
+title: Support US-RSE
+permalink: get-involved/support/
+menubar: get-involved
+---
+
+As the US-RSE organization grows, so do the associated costs with operation.
+Running a grassroots community-driven organization takes a massive amount of effort on behalf of the community members who volunteer their time.
+
+Donations to support US-RSE's ongoing [mission]({{ site.baseurl }}/mission/) can be made at the [US-RSE OCF member page](https://opencollective.com/usrse).
+Donations are tax deductible as allowed to the full extent of the law and can be made via a number of convenient methods.
+
+<!-- It would be nice to have this be a big button at some point -->
+[Support US-RSE!](https://opencollective.com/usrse) 
+
+## Fundraising Initiatives 
+
+Currently the US-RSE is accepting gifts to develop funds focussed on two areas.  
+
+First, we are raising funds to support general operational expenses. The primary general operational needs we are hoping to support at this stage are modest expenses associated with membership management and enhanced communication amongst members. Other activities are currently all volunteer based. 
+
+Second, we are excited to try and grow a student RSE support fund that can help encourage new students to enter and learn about the RSE field. This fund can be contributed to [__here__](https://opencollective.com/usrse/projects/student-spot-awards).
+
+With the advent of our new logo we are working on soon having a way to offer some fun and exciting branded items that can help strengthen fund raising and spread the US-RSE spirit far and wide. 
+
+We are, of course, very interested and open to hearing comments/feedback and suggestions from the broad US-RSE community on financial strategies for the US-RSE. 
+


### PR DESCRIPTION
This will add:
* pages containing information and links pertaining to our financial status with OCF. 
* a support button to direct traffic to the donation page. 

Comments and suggestions welcome. Will need to review with @christophernhill before it's merged too. 

cc @usrse-maintainers
