### PR TITLE
Reduce logo size on landing page.

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -3,11 +3,11 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-4">
-                  <img id="hero-image" src="{{ site.baseurl }}{{ site.banner }}" width="400px">
-                  <img id="hero-small-image" src="{{ site.baseurl }}{{ site.icon }}">
+                  <img id="hero-image" src="{{ site.baseurl }}{{ site.banner }}" width="250px">
+                  <img id="hero-small-image" src="{{ site.baseurl }}{{ site.icon }}" width="60px">
                 </div>
                 <div class="col-md-8">
-                    <h1 class="title is-2 hero-text" style="padding-top:150px">{{ site.hero_line_one }}</h1>
+                    <h1 class="title is-2 hero-text" style="padding-top:50px">{{ site.hero_line_one }}</h1>
                     <p class="subtitle is-4 is-italic hero-text">{{ site.hero_line_two }}</p>
                     {% if page.hero_link %}
                         <a href="{{ page.hero_link | relative_url }}" class="button is-info is-large">{{ page.hero_link_text }}</a>{% endif %}


### PR DESCRIPTION
## Description
Reduce the size of the logo for both the desktop and mobile versions of the landing page. Also reduces top margin above text with logo on desktop page.

## Motivation and Context
Addresses #101.

## Checklist:
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
